### PR TITLE
Change LMA manager 2004 to Uk title from the french title.

### DIFF
--- a/titles/CM/004/info.json
+++ b/titles/CM/004/info.json
@@ -1,5 +1,5 @@
 {
-    "name": "Roger Lemerre: La S\u00e9lection des Champions 2003",
+    "name": "LMA Manager 2003",
     "title_id": "434d0004",
     "releases": [
         {


### PR DESCRIPTION
Changed to Uk title to better match rest of the seires. Fixes #4 and made it easy to find. not sure if you have multiple names in the database, let me know if you can I will add the diffrence region names for rest game in this series.